### PR TITLE
Fixed posts ordering to show most recent posts first

### DIFF
--- a/src/components/Posts.svelte
+++ b/src/components/Posts.svelte
@@ -44,7 +44,6 @@
         // Getting all posts data
         onValue($postsRef, (snapshot) => {  
             let postDataList: Array<Post> = [];
-
             // For each post
             snapshot.forEach((childSnapshot) => {
                 let postEntry = childSnapshot.val();
@@ -62,7 +61,7 @@
                     if (postDataList.includes(postEntry)) {
                         postDataList[postDataList.indexOf(postEntry)] = newPostEntry;
                     } else {
-                        postDataList.push(postEntry);
+                        postDataList.unshift(postEntry);
                     }
                     postViewDataEntries = postDataList;
                 });


### PR DESCRIPTION
I made this fix by appending elements to the front of the list instead of appending them to the end.